### PR TITLE
Rimosso override che causava problemi; fix #51

### DIFF
--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.restore_state import (
     ExtraStoredData,
     RestoredExtraData
 )
-from typing import Any, Dict, override
+from typing import Any, Dict
 
 from . import PUNDataUpdateCoordinator
 from .const import (
@@ -234,7 +234,6 @@ class FasciaPUNSensorEntity(CoordinatorEntity, SensorEntity):
         """Restituisce la fascia corrente come stato"""
         return decode_fascia(self.coordinator.fascia_corrente)
 
-    @override
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         return {


### PR DESCRIPTION
Rimosso decorator `override` che causava problemi al caricamento dell'integrazione su alcuni sistemi specifici (non è chiaro quali siano state le condizioni che causavano questo comportamento).