### PR TITLE
Mostra i risultati dei calcoli PUN nel log

### DIFF
--- a/custom_components/pun_sensor/__init__.py
+++ b/custom_components/pun_sensor/__init__.py
@@ -71,7 +71,9 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
     coordinator = hass.data[DOMAIN][config.entry_id]
 
     # Aggiorna le impostazioni del coordinator dalle opzioni
-    if config.options[CONF_SCAN_HOUR] != coordinator.scan_hour:
+    if (CONF_SCAN_HOUR in config.options) and (
+        config.options[CONF_SCAN_HOUR] != coordinator.scan_hour
+    ):
         # Modificata l'ora di scansione nelle opzioni
         coordinator.scan_hour = config.options[CONF_SCAN_HOUR]
 
@@ -107,7 +109,9 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
             next_update_pun.strftime("%d/%m/%Y %H:%M:%S %z"),
         )
 
-    if config.options[CONF_ACTUAL_DATA_ONLY] != coordinator.actual_data_only:
+    if (CONF_ACTUAL_DATA_ONLY in config.options) and (
+        config.options[CONF_ACTUAL_DATA_ONLY] != coordinator.actual_data_only
+    ):
         # Modificata impostazione 'Usa dati reali'
         coordinator.actual_data_only = config.options[CONF_ACTUAL_DATA_ONLY]
         _LOGGER.debug(

--- a/custom_components/pun_sensor/coordinator.py
+++ b/custom_components/pun_sensor/coordinator.py
@@ -211,10 +211,18 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
         # Logga i dati
         _LOGGER.debug(
             "Numero di dati: %s",
-            ", ".join(str(len(i)) for i in self.pun_data.pun.values()),
+            ", ".join(
+                str(f"{len(dati)} ({fascia.value})")
+                for fascia, dati in self.pun_data.pun.items()
+                if fascia != Fascia.F23
+            ),
         )
         _LOGGER.debug(
-            "Valori PUN: %s", ", ".join(str(f) for f in self.pun_values.value.values())
+            "Valori PUN: %s",
+            ", ".join(
+                f"{prezzo} ({fascia.value})"
+                for fascia, prezzo in self.pun_values.value.items()
+            ),
         )
 
     async def update_fascia(self, now=None):

--- a/custom_components/pun_sensor/coordinator.py
+++ b/custom_components/pun_sensor/coordinator.py
@@ -57,9 +57,11 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Inizializza i valori di configurazione (dalle opzioni o dalla configurazione iniziale)
         self.actual_data_only = config.options.get(
-            CONF_ACTUAL_DATA_ONLY, config.data[CONF_ACTUAL_DATA_ONLY]
+            CONF_ACTUAL_DATA_ONLY, config.data.get(CONF_ACTUAL_DATA_ONLY, False)
         )
-        self.scan_hour = config.options.get(CONF_SCAN_HOUR, config.data[CONF_SCAN_HOUR])
+        self.scan_hour = config.options.get(
+            CONF_SCAN_HOUR, config.data.get(CONF_SCAN_HOUR, 1)
+        )
 
         # Carica il minuto di esecuzione dalla configurazione (o lo crea se non esiste)
         self.scan_minute = 0


### PR DESCRIPTION
Modifica il log di debug indicando nel dettaglio a quale fascia si riferiscono i numeri.
## Log precedente
```
[custom_components.pun_sensor.coordinator] Numero di dati: 360, 110, 82, 168, 0
[custom_components.pun_sensor.coordinator] Valori PUN: 0.12448978344444445, 0.13807011063636362, 0.13305203731707319, 0.11141870720238095, 0.12137003905513938
```
## Log dopo la modifica
```
[custom_components.pun_sensor.coordinator] Numero di dati: 360 (MONO), 110 (F1), 82 (F2), 168 (F3)
[custom_components.pun_sensor.coordinator] Valori PUN: 0.12448978344444445 (MONO), 0.13807011063636362 (F1), 0.13305203731707319 (F2), 0.11141870720238095 (F3), 0.12137003905513938 (F23)
```