### PR TITLE
Hotfix calcolo PUN non corretto causa dati precedenti

### DIFF
--- a/custom_components/pun_sensor/utils.py
+++ b/custom_components/pun_sensor/utils.py
@@ -152,6 +152,10 @@ def extract_xml(archive: ZipFile, pun_data: PunData) -> PunData:
     # Carica le festività
     it_holidays = holidays.IT()  # type: ignore[attr-defined]
 
+    # Azzera i dati precedenti
+    for fascia in pun_data.pun.values():
+        fascia.clear()
+
     # Esamina ogni file XML nello ZIP (ordinandoli prima)
     for fn in sorted(archive.namelist()):
         # Scompatta il file XML in memoria


### PR DESCRIPTION
Nella nuova versione il calcolo del PUN non risulta corretto dopo il download dei primi dati (cioè dal secondo giorno in poi), a causa dei precedenti che non vengono eliminati nella nuova iterazione.