### PR TITLE
Fix calcolo PUN a fine mese; closes #73

### DIFF
--- a/custom_components/pun_sensor/coordinator.py
+++ b/custom_components/pun_sensor/coordinator.py
@@ -178,16 +178,18 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
         """Aggiornamento dati a intervalli prestabiliti."""
 
         # Calcola l'intervallo di date per il mese corrente
-        date_end = dt_util.now().date() + timedelta(
-            days=1
-        )  # Necessario per prezzo zonale (domani)
+        date_end = dt_util.now().date()
         date_start = date(date_end.year, date_end.month, 1)
 
         # All'inizio del mese, aggiunge i valori del mese precedente
         # a meno che CONF_ACTUAL_DATA_ONLY non sia impostato
-        if (not self.actual_data_only) and (date_end.day < 5):
+        if (not self.actual_data_only) and (date_end.day < 4):
             date_start = date_start - timedelta(days=3)
 
+        # Aggiunge un giorno (domani) per il calcolo del prezzo zonale
+        date_end += timedelta(days=1)
+
+        # Converte le date in stringa da passare all'API Mercato elettrico
         start_date_param = date_start.strftime("%Y%m%d")
         end_date_param = date_end.strftime("%Y%m%d")
 


### PR DESCRIPTION
Come ben descritto nell'issue #73, questa PR risolve il problema verificatosi a fine anno.
Il problema si manifesta l'ultimo giorno del mese (per dicembre, il 31) in questa porzione di codice:
https://github.com/virtualdj/pun_sensor/blob/dcdae9237332ac5eebd4e99573bb1becafae4855/custom_components/pun_sensor/coordinator.py#L180-L192

Avendolo modificato nella commit bf13936c75d5b2a711a809bf9993a57538326010 (rispetto alla precedente 1630326b68555e900ffd825be496b9ef5e5d80d0) per scaricare i **dati del giorno successivo** (PUN orario e prezzo zonale), il giorno successivo del 31/12 è il 01/01 che quindi modifica il mese di `date_start` perdendo tutto lo storico dei prezzi del mese di dicembre. Infatti nel log si notano pochissimi file XML:
```text
2024-12-31 02:02:12.108 DEBUG (MainThread) [custom_components.pun_sensor.coordinator] 3 file trovati nell'archivio (20241229MGPPrezzi.xml, 20241230MGPPrezzi.xml, 20241231MGPPrezzi.xml)
```

Questo è chiaramente errato e viene sistemato da questa PR.