### PR TITLE
Aggiornamento DevContainer a Python 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Home Assistant Integration Dev",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "postCreateCommand": ".devcontainer/scripts/setup",
   "containerEnv": {
     "PYTHONASYNCIODEBUG": "1"

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -28,9 +28,10 @@ ffmpeg:
 #   wait: true
 
 # Enable this part if you want to use CodeSpaces
-# http:
-#   use_x_forwarded_for: true
-#   trusted_proxies:
-#     - 127.0.0.1
-#   ip_ban_enabled: true
-#   login_attempts_threshold: 3
+http:
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - ::1
+    - 127.0.0.1
+  ip_ban_enabled: true
+  login_attempts_threshold: 3

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,11 +1,21 @@
 # Example configuration.yaml entry
-default_config:
+# Do not use default_config
+# default_config:
+# But enable the single components instead:
+backup:
+config:
+energy:
+history:
+homeassistant_alerts:
+logbook:
+my:
+sun:
+webhook:
 
 logger:
   default: info
   logs:
     homeassistant.setup: warning
-    homeassistant.components.go2rtc: fatal
     custom_components.pun_sensor: debug
 
 # Disable ffmpeg

--- a/requirements_ha.txt
+++ b/requirements_ha.txt
@@ -1,8 +1,10 @@
 wheel
 colorlog==6.8.2
 pip>=21.3.1
-ruff==0.5.1
-pre-commit==3.7.0
+ruff==0.8.3
+pre-commit==4.0.0
 zlib_ng
 zeroconf
+defusedxml
+mutagen
 homeassistant


### PR DESCRIPTION
Eseguendo il DevContainer con la versione più recente di Home Assistant (2025.1.0) si ottiene questo messaggio nel log:
```text
2025-01-05 07:03:46.433 WARNING (MainThread) [homeassistant.bootstrap] Support for the running Python version 3.12.3 is deprecated and will be removed in Home Assistant 2025.2; Please upgrade Python to 3.13
```
La PR aggiorna la versione di Python e sistema la configurazione evitando di usare quella di default (tramite `default_config`) per far apparire meno messaggi di avvertimento nel terminale. Dopotutto non sono necessari per lo sviluppo di questa integrazione.