### PR TITLE
Mostra la versione di HA nel Devcontainer

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,12 @@
       "problemMatcher": []
     },
     {
+      "label": "Show Home Assistant version",
+      "type": "shell",
+      "command": "clear ; echo -e \"The installed Home Assistant version is $(hass --version).\\n\"",
+      "problemMatcher": []
+    },
+    {
       "label": "Clear Home Assistant config",
       "type": "shell",
       "command": ".devcontainer/scripts/clear-config",


### PR DESCRIPTION
Comando accessibile con F1 da VSCode in modalità DevContainer che visualizza la versione di Home Assistant in uso.