### PR TITLE
Fix Update XML Dati

### DIFF
--- a/custom_components/pun_sensor/utils.py
+++ b/custom_components/pun_sensor/utils.py
@@ -203,7 +203,7 @@ def extract_xml(archive: ZipFile, pun_data: PunData, today: date) -> PunData:
         # Parsing dell'XML (1 file = 1 giorno)
         xml_root = xml_tree.getroot()
 
-        if xml_root.find("Prezzi5"):
+        if xml_root.find("Prezzi15"):
             continue
         else:
             # Estrae la data dal primo elemento (sarà identica per gli altri)

--- a/custom_components/pun_sensor/utils.py
+++ b/custom_components/pun_sensor/utils.py
@@ -203,39 +203,64 @@ def extract_xml(archive: ZipFile, pun_data: PunData, today: date) -> PunData:
         # Parsing dell'XML (1 file = 1 giorno)
         xml_root = xml_tree.getroot()
 
-        # Estrae la data dal primo elemento (sarà identica per gli altri)
-        dat_string = xml_root.find("Prezzi").find("Data").text  # YYYYMMDD
-
-        # Converte la stringa giorno in data
-        dat_date = date(
-            int(dat_string[0:4]),
-            int(dat_string[4:6]),
-            int(dat_string[6:8]),
-        )
-
-        # Verifica la festività
-        festivo = dat_date in it_holidays
-
-        # Estrae le rimanenti informazioni
-        for prezzi in xml_root.iter("Prezzi"):
-            # Estrae l'ora dall'XML
-            ora = int(prezzi.find("Ora").text) - 1  # 1..24
-
-            # Estrae il prezzo PUN dall'XML in un float
-            if (prezzo_xml := prezzi.find("PUN")) is not None:
-                prezzo_string = prezzo_xml.text.replace(".", "").replace(",", ".")
-                prezzo = float(prezzo_string) / 1000
-
-                # Per le medie mensili, considera solo i dati fino ad oggi
-                if dat_date <= today:
-                    # Estrae la fascia oraria
-                    fascia = get_fascia_for_xml(dat_date, festivo, ora)
-
-                    # Calcola le statistiche
-                    pun_data.pun[Fascia.MONO].append(prezzo)
-                    pun_data.pun[fascia].append(prezzo)
-
-                # Per il PUN orario, considera solo oggi e domani
+        if xml_root.find("Prezzi5"):
+            continue
+        else:
+            # Estrae la data dal primo elemento (sarà identica per gli altri)
+            dat_string = xml_root.find("Prezzi").find("Data").text  # YYYYMMDD
+    
+            # Converte la stringa giorno in data
+            dat_date = date(
+                int(dat_string[0:4]),
+                int(dat_string[4:6]),
+                int(dat_string[6:8]),
+            )
+    
+            # Verifica la festività
+            festivo = dat_date in it_holidays
+    
+            # Estrae le rimanenti informazioni
+            for prezzi in xml_root.iter("Prezzi"):
+                # Estrae l'ora dall'XML
+                ora = int(prezzi.find("Ora").text) - 1  # 1..24
+    
+                # Estrae il prezzo PUN dall'XML in un float
+                if (prezzo_xml := prezzi.find("PUN")) is not None:
+                    prezzo_string = prezzo_xml.text.replace(".", "").replace(",", ".")
+                    prezzo = float(prezzo_string) / 1000
+    
+                    # Per le medie mensili, considera solo i dati fino ad oggi
+                    if dat_date <= today:
+                        # Estrae la fascia oraria
+                        fascia = get_fascia_for_xml(dat_date, festivo, ora)
+    
+                        # Calcola le statistiche
+                        pun_data.pun[Fascia.MONO].append(prezzo)
+                        pun_data.pun[fascia].append(prezzo)
+    
+                    # Per il PUN orario, considera solo oggi e domani
+                    if dat_date >= today:
+                        # Compone l'orario
+                        orario_prezzo = datetime_to_packed_string(
+                            datetime(
+                                year=dat_date.year,
+                                month=dat_date.month,
+                                day=dat_date.day,
+                                hour=ora,
+                                minute=0,
+                                second=0,
+                                microsecond=0,
+                            )
+                        )
+                        # E salva il prezzo per quell'orario
+                        pun_data.pun_orari[orario_prezzo] = prezzo
+                else:
+                    # PUN non valido
+                    _LOGGER.warning(
+                        "PUN non specificato per %s ad orario: %s.", dat_string, ora
+                    )
+    
+                # Per i prezzi zonali, considera solo oggi e domani
                 if dat_date >= today:
                     # Compone l'orario
                     orario_prezzo = datetime_to_packed_string(
@@ -249,43 +274,21 @@ def extract_xml(archive: ZipFile, pun_data: PunData, today: date) -> PunData:
                             microsecond=0,
                         )
                     )
-                    # E salva il prezzo per quell'orario
-                    pun_data.pun_orari[orario_prezzo] = prezzo
-            else:
-                # PUN non valido
-                _LOGGER.warning(
-                    "PUN non specificato per %s ad orario: %s.", dat_string, ora
-                )
-
-            # Per i prezzi zonali, considera solo oggi e domani
-            if dat_date >= today:
-                # Compone l'orario
-                orario_prezzo = datetime_to_packed_string(
-                    datetime(
-                        year=dat_date.year,
-                        month=dat_date.month,
-                        day=dat_date.day,
-                        hour=ora,
-                        minute=0,
-                        second=0,
-                        microsecond=0,
-                    )
-                )
-
-                # Controlla che la zona del prezzo zonale sia impostata
-                if pun_data.zona is not None:
-                    # Estrae il prezzo zonale dall'XML in un float
-                    # basandosi sul nome dell'enum
-                    if (
-                        prezzo_zonale_xml := prezzi.find(pun_data.zona.name)
-                    ) is not None:
-                        prezzo_zonale_string = prezzo_zonale_xml.text.replace(
-                            ".", ""
-                        ).replace(",", ".")
-                        pun_data.prezzi_zonali[orario_prezzo] = (
-                            float(prezzo_zonale_string) / 1000
-                        )
-                    else:
-                        pun_data.prezzi_zonali[orario_prezzo] = None
+    
+                    # Controlla che la zona del prezzo zonale sia impostata
+                    if pun_data.zona is not None:
+                        # Estrae il prezzo zonale dall'XML in un float
+                        # basandosi sul nome dell'enum
+                        if (
+                            prezzo_zonale_xml := prezzi.find(pun_data.zona.name)
+                        ) is not None:
+                            prezzo_zonale_string = prezzo_zonale_xml.text.replace(
+                                ".", ""
+                            ).replace(",", ".")
+                            pun_data.prezzi_zonali[orario_prezzo] = (
+                                float(prezzo_zonale_string) / 1000
+                            )
+                        else:
+                            pun_data.prezzi_zonali[orario_prezzo] = None
 
     return pun_data


### PR DESCRIPTION
Ciao,

Ho notato stamattina il problema con il recupero dei dati dal GME, controllando un attimo l'output dell'XML ho notato che hanno aggiunto un file contenente i prezzi a 15 minuti, il file contiene la root "Prezzi15" per le entry dei prezzi, e sembra essere il primo ad essere elaborato, passando quindi alla funzione di estrazione delle fasce un dato nullo.

Controllando la presenza della root "Prezzi15" possiamo skippare all'iterazione successiva (file successivo) nel for loop che estrae i dati dall'XML, risolvendo cosi' il problema.