### PR TITLE
Fix esaurimento tentativi falliti

### DIFF
--- a/custom_components/pun_sensor/__init__.py
+++ b/custom_components/pun_sensor/__init__.py
@@ -110,7 +110,7 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
             coordinator.schedule_token = None
 
         # Schedula la prossima esecuzione
-        coordinator.web_retries = WEB_RETRIES_MINUTES
+        coordinator.web_retries = WEB_RETRIES_MINUTES.copy()
         coordinator.schedule_token = async_track_point_in_time(
             coordinator.hass, coordinator.update_pun, next_update_pun
         )
@@ -134,7 +134,7 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
             coordinator.schedule_token = None
 
         # Esegue un nuovo aggiornamento immediatamente
-        coordinator.web_retries = WEB_RETRIES_MINUTES
+        coordinator.web_retries = WEB_RETRIES_MINUTES.copy()
         coordinator.schedule_token = async_call_later(
             coordinator.hass, timedelta(seconds=5), coordinator.update_pun
         )
@@ -169,7 +169,7 @@ async def update_listener(hass: HomeAssistant, config: ConfigEntry) -> None:
                 coordinator.schedule_token = None
 
             # Esegue un nuovo aggiornamento immediatamente
-            coordinator.web_retries = WEB_RETRIES_MINUTES
+            coordinator.web_retries = WEB_RETRIES_MINUTES.copy()
             coordinator.schedule_token = async_call_later(
                 coordinator.hass, timedelta(seconds=5), coordinator.update_pun
             )

--- a/custom_components/pun_sensor/coordinator.py
+++ b/custom_components/pun_sensor/coordinator.py
@@ -124,7 +124,7 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
         self.update_scan_minutes_from_config(hass=hass, config=config, new_minute=False)
 
         # Inizializza i valori di default
-        self.web_retries = WEB_RETRIES_MINUTES
+        self.web_retries = WEB_RETRIES_MINUTES.copy()
         self.schedule_token = None
         self.pun_values: PunValues = PunValues()
         self.fascia_corrente: Fascia | None = None
@@ -340,7 +340,7 @@ class PUNDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Se non ci sono eccezioni, ha avuto successo
             # Ricarica i tentativi per la prossima esecuzione
-            self.web_retries = WEB_RETRIES_MINUTES
+            self.web_retries = WEB_RETRIES_MINUTES.copy()
 
         # Errore nel fetch dei dati se la response non e' 200
         # pylint: disable=broad-exception-caught


### PR DESCRIPTION
In caso di ripetuti tentativi falliti, la lista non veniva ripristinata e quindi potrebbero _teoricamente_ presentarsi errori (in realtà essendo il download giornaliero non dovrebbe comunque accadere).
Questa PR risolve il problema perché la lista viene copiata.