### PR TITLE
Fix data non convertita corretamente dal fuso nel giorno di cambio ora

### DIFF
--- a/custom_components/pun_sensor/utils.py
+++ b/custom_components/pun_sensor/utils.py
@@ -161,6 +161,7 @@ def get_hour_datetime(dataora: datetime) -> datetime:
         minute=0,
         second=0,
         microsecond=0,
+        fold=dataora.fold,
         tzinfo=dataora.tzinfo,
     )
 


### PR DESCRIPTION
A causa di questo bug, di cui non mi ero accorto inizialmente, la PR #96 non era sufficiente a risolvere il problema del prezzo nei giorni di cambio orario (es. 27/10/2024 o il prossimo 26/10/2025).

## Prima della modifica

Impostando l'ora alle prime 02:57 di notte del giorno di cambio 27/10/2024 (fuso +02:00), la fascia XML identificata dopo 3 minuti è la `3`, ma è errata perché in realtà dovrebbe essere la `4` ⚠️.

```
2024-10-27 02:57:05.956 DEBUG (MainThread) [custom_components.pun_sensor.coordinator] Ora corrente sistema: Sun 27/10/2024 02:57:05 +0200
... tre minuti dopo ...
2024-10-27 02:00:00.005 DEBUG (MainThread) [custom_components.pun_sensor.sensor] Aggiornamento data prezzo zonale: 2024-10-27 02:00:00+02:00 (XML: 3)
2024-10-27 02:00:00.005 DEBUG (MainThread) [custom_components.pun_sensor.sensor] Aggiornamento data PUN orario: 2024-10-27 02:00:00+02:00 (XML: 3)
```

Questo perché le fasce sono:

1. Dalle 0 all'1
2. Dall'1 alle 2
3. Dalle prime 2 alle 2.59 (avviato Home Assistant qui)
4. Dalle seconde 2 (ex 3, tirate indietro di un'ora) alle 3 (trascorsi i 3 minuti dall'avvio, dovremmo essere qui)

## Dopo l'applicazione della PR

```
2024-10-27 02:57:05.658 DEBUG (MainThread) [custom_components.pun_sensor.coordinator] Ora corrente sistema: Sun 27/10/2024 02:57:05 +0200
... tre minuti dopo ...
2024-10-27 02:00:00.002 DEBUG (MainThread) [custom_components.pun_sensor.sensor] Aggiornamento data prezzo zonale: 2024-10-27 02:00:00+01:00 (XML: 4)
2024-10-27 02:00:00.003 DEBUG (MainThread) [custom_components.pun_sensor.sensor] Aggiornamento data PUN orario: 2024-10-27 02:00:00+01:00 (XML: 4)
```
Avviando HA dopo 1 ora quindi alle seconde 02:59 dello stesso giorno (fuso 01+00), la fascia XML risultante è la corretta `5`.
```
2024-10-27 02:59:04.702 DEBUG (MainThread) [custom_components.pun_sensor.coordinator] Ora corrente sistema: Sun 27/10/2024 02:59:04 +0100
... un minuto dopo ...
2024-10-27 03:00:00.002 DEBUG (MainThread) [custom_components.pun_sensor.sensor] Aggiornamento data prezzo zonale: 2024-10-27 03:00:00+01:00 (XML: 5)
2024-10-27 03:00:00.002 DEBUG (MainThread) [custom_components.pun_sensor.sensor] Aggiornamento data PUN orario: 2024-10-27 03:00:00+01:00 (XML: 5)
```