### PR TITLE
Fix calcolo giorno successivo negli attributi per i giorni di cambio ora

### DIFF
--- a/custom_components/pun_sensor/sensor.py
+++ b/custom_components/pun_sensor/sensor.py
@@ -600,7 +600,9 @@ class PrezzoZonaleSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
                 )
 
             # Prezzi di domani
-            domani = add_timedelta_via_utc(dt=self.coordinator.orario_prezzo, days=1)
+            domani = add_timedelta_via_utc(
+                dt=self.coordinator.orario_prezzo, full_days=1
+            )
             max_ore_domani: int = get_total_hours(domani)
             for h in range(max_ore_domani):
                 data_ora_prezzo = get_datetime_from_ordinal_hour(domani, (1 + h))
@@ -831,7 +833,7 @@ class PrezzoZonale15MinSensorEntity(CoordinatorEntity, SensorEntity, RestoreEnti
 
             # Prezzi di domani
             domani = add_timedelta_via_utc(
-                dt=self.coordinator.orario_prezzo_15min, days=1
+                dt=self.coordinator.orario_prezzo_15min, full_days=1
             )
             max_15min_domani: int = 4 * get_total_hours(domani)
             for p in range(max_15min_domani):
@@ -999,7 +1001,7 @@ class PUNOrarioSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
             attributes[str(data_ora_prezzo)] = self._pun_orari.get(str(data_ora_prezzo))
 
         # Prezzi di domani
-        domani = add_timedelta_via_utc(dt=self.coordinator.orario_prezzo, days=1)
+        domani = add_timedelta_via_utc(dt=self.coordinator.orario_prezzo, full_days=1)
         max_ore_domani: int = get_total_hours(domani)
         for h in range(max_ore_domani):
             data_ora_prezzo = get_datetime_from_ordinal_hour(domani, (1 + h))
@@ -1166,7 +1168,9 @@ class PUN15MinSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
             attributes[str(data_ora_prezzo)] = self._pun_15min.get(str(data_ora_prezzo))
 
         # Prezzi di domani
-        domani = add_timedelta_via_utc(dt=self.coordinator.orario_prezzo_15min, days=1)
+        domani = add_timedelta_via_utc(
+            dt=self.coordinator.orario_prezzo_15min, full_days=1
+        )
         max_15min_domani: int = 4 * get_total_hours(domani)
         for p in range(max_15min_domani):
             data_ora_prezzo = get_datetime_from_periodo_15min(domani, (1 + p))

--- a/custom_components/pun_sensor/utils.py
+++ b/custom_components/pun_sensor/utils.py
@@ -262,7 +262,7 @@ def add_timedelta_via_utc(
     *,
     dt: datetime,
     delta: timedelta | None = None,
-    days: int = 0,
+    full_days: int = 0,
     hours: int = 0,
     minutes: int = 0,
     ref_tz: ZoneInfo = ZoneInfo("Europe/Rome"),
@@ -272,7 +272,7 @@ def add_timedelta_via_utc(
     Args:
         dt: datetime con timezone su cui operare
         delta: timedelta da aggiungere
-        days: giorni da aggiungere (se delta è None)
+        full_days: giorni completi (non 24 ore!) da aggiungere (se delta è None)
         hours: ore da aggiungere (se delta è None)
         minutes: minuti da aggiungere (se delta è None)
         ref_tz: timezone di riferimento per il calcolo (di default usa "Europe/Rome")
@@ -292,7 +292,14 @@ def add_timedelta_via_utc(
 
     # Controllo timedelta
     if delta is None:
-        delta = timedelta(days=days, hours=hours, minutes=minutes)
+        # Verifica se sono specificati i giorni
+        if full_days != 0:
+            # I giorni si intendono sempre completi, non 24 ore in UTC
+            # (quindi composti da 23 o 25 ore nei giorni di cambio ora)
+            return dt + timedelta(days=full_days)
+
+        # Altrimenti considera il delta di ore e minuti
+        delta = timedelta(hours=hours, minutes=minutes)
 
     # Aggiunge il delta in UTC (per considerare anche i cambiamenti ora solare/legale)
     return (dt.astimezone(timezone.utc) + delta).astimezone(ref_tz)


### PR DESCRIPTION
Quando viene calcolato il giorno successivo (domani) per determinare i prezzi negli attributi dei sensori, il risultato era sbagliato nei giorni di cambio ora.

Fixes #104