### PR TITLE
Fix devcontainer con le versioni recenti di Home Assistant

### DIFF
--- a/.devcontainer/scripts/setup
+++ b/.devcontainer/scripts/setup
@@ -4,6 +4,9 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
+# Remove yarn list to avoid errors in apt-get
+sudo rm -f /etc/apt/sources.list.d/yarn.list
+
 # Install libpcap and libturbojpeg to avoid errors in Home Assistant
 sudo apt-get update
 sudo apt-get install -y libpcap-dev libturbojpeg0

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Home Assistant Config
+# Home Assistant config
 /config/*
 !/config/configuration.yaml
+
+# Other Home Assistant custom_components
+/custom_components/*
+!/custom_components/pun_sensor/*

--- a/requirements_ha.txt
+++ b/requirements_ha.txt
@@ -10,4 +10,7 @@ mutagen
 hassil
 home_assistant_intents
 numpy
+pyturbojpeg<2.0.0
+pymicro-vad
+pyspeex-noise
 homeassistant


### PR DESCRIPTION
Evita gli errori in fase di creazione del devcontainer in VS Code.
Tra questi la firma GPG mancante per _Yarn_ e gli errori all'avvio di Home Assistant per la mancanza dei moduli _turbojpeg_, _pymicro-vad_ e _pyspeex-noise_ (che purtroppo non si possono disabilitare).